### PR TITLE
EXEC_NEXT calculated on re-init, spotless applied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'pipelite'
-version = '1.0.105'
+version = '1.0.106'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 

--- a/src/main/java/pipelite/executor/SimpleLsfExecutor.java
+++ b/src/main/java/pipelite/executor/SimpleLsfExecutor.java
@@ -57,7 +57,8 @@ public class SimpleLsfExecutor extends AbstractLsfExecutor<SimpleLsfExecutorPara
           "\"rusage[mem="
               + memStr
               + ((memoryTimeout == null || memoryTimeout.toMinutes() < 0)
-                  ? ""  : ":duration=" + memoryTimeout.toMinutes())
+                  ? ""
+                  : ":duration=" + memoryTimeout.toMinutes())
               + "]\"");
     }
 

--- a/src/main/java/pipelite/service/RegisteredPipelineService.java
+++ b/src/main/java/pipelite/service/RegisteredPipelineService.java
@@ -142,6 +142,7 @@ public class RegisteredPipelineService {
                     savedScheduleEntity.get().setCron(cron);
                     savedScheduleEntity.get().setDescription(CronUtils.describe(cron));
                     savedScheduleEntity.get().setServiceName(serviceName);
+                    savedScheduleEntity.get().setNextTime(CronUtils.launchTime(cron));
                     scheduleService.saveSchedule(savedScheduleEntity.get());
                   } catch (Exception ex) {
                     throw new PipeliteException(

--- a/src/test/java/pipelite/executor/SimpleLsfExecutorSubmitCmdTest.java
+++ b/src/test/java/pipelite/executor/SimpleLsfExecutorSubmitCmdTest.java
@@ -66,31 +66,28 @@ public class SimpleLsfExecutorSubmitCmdTest {
     SimpleLsfExecutor executor = new SimpleLsfExecutor();
     executor.setCmd("test");
     SimpleLsfExecutorParameters params =
-            SimpleLsfExecutorParameters.builder()
-                    .workDir(Files.createTempDirectory("TEMP").toString())
-                    .cpu(2)
-                    .memory(1)
-                    .memoryUnits("M")
-                    .queue("TEST")
-                    .timeout(Duration.ofMinutes(1))
-                    .build();
+        SimpleLsfExecutorParameters.builder()
+            .workDir(Files.createTempDirectory("TEMP").toString())
+            .cpu(2)
+            .memory(1)
+            .memoryUnits("M")
+            .queue("TEST")
+            .timeout(Duration.ofMinutes(1))
+            .build();
     executor.setExecutorParams(params);
 
     Stage stage = Stage.builder().stageName(STAGE_NAME).executor(executor).build();
     StageExecutorRequest request =
-            StageExecutorRequest.builder()
-                    .pipelineName(PIPELINE_NAME)
-                    .processId(PROCESS_ID)
-                    .stage(stage)
-                    .build();
+        StageExecutorRequest.builder()
+            .pipelineName(PIPELINE_NAME)
+            .processId(PROCESS_ID)
+            .stage(stage)
+            .build();
     String outFile = AbstractLsfExecutor.getOutFile(request, params);
     executor.setOutFile(outFile);
     String submitCmd = executor.getSubmitCmd(request);
     assertThat(submitCmd)
-            .isEqualTo(
-                    "bsub -oo "
-                            + outFile
-                            + " -n 2 -M 1M -R \"rusage[mem=1M]\" -W 1 -q TEST test");
+        .isEqualTo("bsub -oo " + outFile + " -n 2 -M 1M -R \"rusage[mem=1M]\" -W 1 -q TEST test");
   }
 
   @Test
@@ -130,27 +127,26 @@ public class SimpleLsfExecutorSubmitCmdTest {
     SimpleLsfExecutor executor = new SimpleLsfExecutor();
     executor.setCmd("test");
     SimpleLsfExecutorParameters params =
-            SimpleLsfExecutorParameters.builder()
-                    .workDir(Files.createTempDirectory("TEMP").toString())
-                    .cpu(2)
-                    .memory(1)
-                    .queue("TEST")
-                    .timeout(Duration.ofMinutes(1))
-                    .build();
+        SimpleLsfExecutorParameters.builder()
+            .workDir(Files.createTempDirectory("TEMP").toString())
+            .cpu(2)
+            .memory(1)
+            .queue("TEST")
+            .timeout(Duration.ofMinutes(1))
+            .build();
     executor.setExecutorParams(params);
 
     Stage stage = Stage.builder().stageName(STAGE_NAME).executor(executor).build();
     StageExecutorRequest request =
-            StageExecutorRequest.builder()
-                    .pipelineName(PIPELINE_NAME)
-                    .processId(PROCESS_ID)
-                    .stage(stage)
-                    .build();
+        StageExecutorRequest.builder()
+            .pipelineName(PIPELINE_NAME)
+            .processId(PROCESS_ID)
+            .stage(stage)
+            .build();
     String outFile = AbstractLsfExecutor.getOutFile(request, params);
     executor.setOutFile(outFile);
     String submitCmd = executor.getSubmitCmd(request);
     assertThat(submitCmd)
-            .isEqualTo(
-                    "bsub -oo " + outFile + " -n 2 -M 1 -R \"rusage[mem=1]\" -W 1 -q TEST test");
+        .isEqualTo("bsub -oo " + outFile + " -n 2 -M 1 -R \"rusage[mem=1]\" -W 1 -q TEST test");
   }
 }

--- a/src/test/java/pipelite/executor/SshSimpleLsfExecutorTest.java
+++ b/src/test/java/pipelite/executor/SshSimpleLsfExecutorTest.java
@@ -47,7 +47,7 @@ public class SshSimpleLsfExecutorTest {
         SimpleLsfExecutorParameters.builder()
             .host(lsfTestConfiguration.getHost())
             .workDir(lsfTestConfiguration.getWorkDir())
-            .timeout(Duration.ofSeconds(60))
+            .timeout(Duration.ofSeconds(180))
             .build());
 
     String stageName = UniqueStringGenerator.randomStageName();


### PR DESCRIPTION
Whenever a schedule fails it is (was) impossible to run a fixed version before EXEC_NEXT time (calculated on the previous execution) without removing DB rows. This version (hopefully) updates EXEC_NEXT on schedule re-initialisation.  