### PR TITLE
Ena 4392

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'pipelite'
-version = '1.3.5'
+version = '1.3.6'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 

--- a/src/main/java/pipelite/executor/cmd/CmdRunner.java
+++ b/src/main/java/pipelite/executor/cmd/CmdRunner.java
@@ -51,11 +51,22 @@ public interface CmdRunner {
    * @param stderr the stderr
    * @return the execution result
    */
-  static StageExecutorResult result(String cmd, int exitCode, String stdout, String stderr) {
-    StageExecutorResult result =
-        (exitCode == EXIT_CODE_SUCCESS)
-            ? StageExecutorResult.success()
-            : StageExecutorResult.error();
+  static StageExecutorResult result(
+      String cmd,
+      int exitCode,
+      String stdout,
+      String stderr,
+      CmdExecutorParameters executorParams) {
+    StageExecutorResult result;
+    if (executorParams.getPermanentErrors() != null
+        && executorParams.getPermanentErrors().contains(exitCode)) {
+      result = StageExecutorResult.permanentError();
+    } else {
+      result =
+          (exitCode == EXIT_CODE_SUCCESS)
+              ? StageExecutorResult.success()
+              : StageExecutorResult.error();
+    }
     result.addAttribute(StageExecutorResultAttribute.COMMAND, cmd);
     result.addAttribute(StageExecutorResultAttribute.EXIT_CODE, exitCode);
     result.setStageLog((stdout != null ? stdout : "") + (stderr != null ? stderr : ""));

--- a/src/main/java/pipelite/executor/cmd/LocalCmdRunner.java
+++ b/src/main/java/pipelite/executor/cmd/LocalCmdRunner.java
@@ -10,8 +10,12 @@
  */
 package pipelite.executor.cmd;
 
-import java.io.*;
-import java.nio.file.*;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import lombok.extern.flogger.Flogger;
@@ -74,7 +78,8 @@ public class LocalCmdRunner implements CmdRunner {
       log.atInfo().log("Executing local call: %s", cmd);
 
       int exitCode = apacheExecutor.execute(commandLine, executorParams.getEnv());
-      return CmdRunner.result(cmd, exitCode, getStream(stdoutStream), getStream(stderrStream));
+      return CmdRunner.result(
+          cmd, exitCode, getStream(stdoutStream), getStream(stderrStream), executorParams);
 
     } catch (Exception ex) {
       throw new PipeliteException("Failed to execute local call: " + cmd, ex);

--- a/src/main/java/pipelite/executor/cmd/SshCmdRunner.java
+++ b/src/main/java/pipelite/executor/cmd/SshCmdRunner.java
@@ -78,7 +78,8 @@ public class SshCmdRunner implements CmdRunner {
       }
 
       int exitCode = channel.getExitStatus();
-      return CmdRunner.result(cmd, exitCode, getStream(stdoutStream), getStream(stderrStream));
+      return CmdRunner.result(
+          cmd, exitCode, getStream(stdoutStream), getStream(stderrStream), executorParams);
 
     } catch (Exception ex) {
       throw new PipeliteException("Failed to execute ssh call: " + cmd, ex);

--- a/src/main/java/pipelite/runner/process/ProcessRunner.java
+++ b/src/main/java/pipelite/runner/process/ProcessRunner.java
@@ -235,13 +235,9 @@ public class ProcessRunner {
   }
 
   private void endStageExecution(Stage stage, StageExecutorResult result) {
-    pipeliteServices.stage().endExecution(stage, result);
     if (result.isSuccess()) {
       resetDependentStageExecution(process, stage);
-    } else {
-      pipeliteServices.mail().sendStageExecutionMessage(process, stage);
     }
-    pipeliteMetrics.pipeline(pipelineName).stage().endStageExecution(result);
   }
 
   /**

--- a/src/main/java/pipelite/runner/stage/StageRunner.java
+++ b/src/main/java/pipelite/runner/stage/StageRunner.java
@@ -172,8 +172,17 @@ public class StageRunner {
       } else if (result.isError()) {
         logContext(log.atInfo()).log(executorType + " stage execution failed");
       }
+      endStageExecution(stage, result);
       resultCallback.accept(result);
     }
+  }
+
+  private void endStageExecution(Stage stage, StageExecutorResult result) {
+    pipeliteServices.stage().endExecution(stage, result);
+    if (!result.isSuccess()) {
+      pipeliteServices.mail().sendStageExecutionMessage(process, stage);
+    }
+    pipeliteMetrics.pipeline(pipelineName).stage().endStageExecution(result);
   }
 
   public void terminate() {

--- a/src/main/java/pipelite/service/StageService.java
+++ b/src/main/java/pipelite/service/StageService.java
@@ -139,6 +139,10 @@ public class StageService {
   public StageEntity endExecution(Stage stage, StageExecutorResult result) {
     stage.incrementImmediateExecutionCount();
     StageEntity stageEntity = stage.getStageEntity();
+    if (result.isPermanentError()) {
+      // Set the execution count to maximum retries to prevent further executions.
+      stageEntity.setExecutionCount(stage.getExecutor().getExecutorParams().getMaximumRetries());
+    }
     stageEntity.endExecution(result);
     StageEntity savedStage = saveStage(stageEntity);
     saveStageLog(StageLogEntity.endExecution(stageEntity, result));

--- a/src/main/java/pipelite/stage/executor/StageExecutorResult.java
+++ b/src/main/java/pipelite/stage/executor/StageExecutorResult.java
@@ -37,6 +37,9 @@ public class StageExecutorResult {
   /** True if an interrupted error has been registered. */
   private boolean interruptedError;
 
+  /** True if a permanent error has been registered. */
+  private boolean permanentError;
+
   private final Map<String, String> attributes = new HashMap<>();
 
   public StageExecutorResult(StageState stageState) {
@@ -60,6 +63,10 @@ public class StageExecutorResult {
 
   public boolean isError() {
     return StageState.isError(stageState);
+  }
+
+  public boolean isPermanentError() {
+    return permanentError;
   }
 
   public static StageExecutorResult active() {
@@ -108,6 +115,17 @@ public class StageExecutorResult {
   public static StageExecutorResult interruptedError() {
     StageExecutorResult result = error();
     result.interruptedError = true;
+    return result;
+  }
+
+  /**
+   * Creates a permanent error.
+   *
+   * @return the stage execution result
+   */
+  public static StageExecutorResult permanentError() {
+    StageExecutorResult result = error();
+    result.permanentError = true;
     return result;
   }
 

--- a/src/main/java/pipelite/stage/parameters/AwsBatchExecutorParameters.java
+++ b/src/main/java/pipelite/stage/parameters/AwsBatchExecutorParameters.java
@@ -10,6 +10,7 @@
  */
 package pipelite.stage.parameters;
 
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -46,6 +47,9 @@ public class AwsBatchExecutorParameters extends ExecutorParameters {
     applyDefault(this::getRegion, this::setRegion, defaultParams::getRegion);
     applyDefault(this::getQueue, this::setQueue, defaultParams::getQueue);
     applyDefault(this::getDefinition, this::setDefinition, defaultParams::getDefinition);
+    if (parameters == null) {
+      parameters = new HashMap<>();
+    }
     applyMapDefaults(parameters, defaultParams.parameters);
   }
 

--- a/src/main/java/pipelite/stage/parameters/CmdExecutorParameters.java
+++ b/src/main/java/pipelite/stage/parameters/CmdExecutorParameters.java
@@ -10,11 +10,11 @@
  */
 package pipelite.stage.parameters;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import pipelite.configuration.ExecutorConfiguration;
 
@@ -38,6 +38,8 @@ public class CmdExecutorParameters extends ExecutorParameters {
   /** The working directory where the output file and job definition files are written. */
   private String workDir;
 
+  /** The permanent error exit codes. Permanent errors are never retried. */
+  @Singular private List<Integer> permanentErrors;
 
   /** The number of last bytes from the output file saved in the stage log. */
   @Builder.Default private int logBytes = DEFAULT_LOG_BYTES;
@@ -52,7 +54,14 @@ public class CmdExecutorParameters extends ExecutorParameters {
     applyDefault(this::getUser, this::setUser, defaultParams::getUser);
     applyDefault(this::getWorkDir, this::setWorkDir, defaultParams::getWorkDir);
     applyDefault(this::getLogBytes, this::setLogBytes, defaultParams::getLogBytes);
+    if (env == null) {
+      env = new HashMap<>();
+    }
     applyMapDefaults(env, defaultParams.env);
+    if (permanentErrors == null) {
+      permanentErrors = new ArrayList<>();
+    }
+    applyListDefaults(permanentErrors, defaultParams.permanentErrors);
   }
 
   @Override

--- a/src/main/java/pipelite/stage/parameters/ExecutorParameters.java
+++ b/src/main/java/pipelite/stage/parameters/ExecutorParameters.java
@@ -15,8 +15,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.Data;
@@ -54,14 +53,21 @@ public class ExecutorParameters {
     }
   }
 
-  public static <K, V> void applyMapDefaults(Map<K, V> params, Map<K, V> defaultParams) {
-    if (params == null) {
-      params = new HashMap<>();
+  public static <K, V> void applyMapDefaults(Map<K, V> map, Map<K, V> defaultMap) {
+    if (defaultMap != null) {
+      for (K key : defaultMap.keySet()) {
+        if (!map.containsKey(key)) {
+          map.put(key, defaultMap.get(key));
+        }
+      }
     }
-    if (defaultParams != null) {
-      for (K key : defaultParams.keySet()) {
-        if (!params.containsKey(key)) {
-          params.put(key, defaultParams.get(key));
+  }
+
+  public static <V> void applyListDefaults(List<V> list, List<V> defaultList) {
+    if (defaultList != null) {
+      for (V defaultValue : defaultList) {
+        if (!list.contains(defaultValue)) {
+          list.add(defaultValue);
         }
       }
     }

--- a/src/main/java/pipelite/stage/parameters/LsfExecutorParameters.java
+++ b/src/main/java/pipelite/stage/parameters/LsfExecutorParameters.java
@@ -10,6 +10,7 @@
  */
 package pipelite.stage.parameters;
 
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -56,6 +57,9 @@ public class LsfExecutorParameters extends CmdExecutorParameters {
     super.applyDefaults(defaultParams);
     applyDefault(this::getDefinition, this::setDefinition, defaultParams::getDefinition);
     applyDefault(this::getFormat, this::setFormat, defaultParams::getFormat);
+    if (parameters == null) {
+      parameters = new HashMap<>();
+    }
     applyMapDefaults(parameters, defaultParams.parameters);
   }
 

--- a/src/test/java/pipelite/executor/cmd/LocalCmdRunnerTest.java
+++ b/src/test/java/pipelite/executor/cmd/LocalCmdRunnerTest.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import pipelite.stage.executor.StageExecutorResult;
+import pipelite.stage.executor.StageExecutorResultAttribute;
 import pipelite.stage.parameters.CmdExecutorParameters;
 
 public class LocalCmdRunnerTest {
@@ -35,5 +37,23 @@ public class LocalCmdRunnerTest {
     assertThat(tempFile).exists();
     cmdRunner.deleteFile(tempFile);
     assertThat(tempFile).doesNotExist();
+  }
+
+  @Test
+  public void error() {
+    LocalCmdRunner cmdRunner = new LocalCmdRunner(CmdExecutorParameters.builder().build());
+    StageExecutorResult result = cmdRunner.execute("date");
+    assertThat(result.isError()).isFalse();
+    assertThat(result.getAttribute(StageExecutorResultAttribute.EXIT_CODE)).isEqualTo("0");
+  }
+
+  @Test
+  public void permanentError() {
+    LocalCmdRunner cmdRunner =
+        new LocalCmdRunner(CmdExecutorParameters.builder().permanentError(0).build());
+    StageExecutorResult result = cmdRunner.execute("date");
+    assertThat(result.isError()).isTrue();
+    assertThat(result.isPermanentError()).isTrue();
+    assertThat(result.getAttribute(StageExecutorResultAttribute.EXIT_CODE)).isEqualTo("0");
   }
 }


### PR DESCRIPTION
1.3.6: support for permanent error exit codes. Execution count is set to maximum execution count + 1 for permanent error exit codes.